### PR TITLE
Clarify package string for private github repos

### DIFF
--- a/packages/endpoints/git.md
+++ b/packages/endpoints/git.md
@@ -44,14 +44,20 @@ You can specify packages from folder endpoints as dependencies in your `box.json
 
 ## Authentication
 
-Git repos that allow anonymous pulls do not require any additional configuration for authentication.  CommandBox's Git endpoint supports SSH authentication via public/private keys by using the `git+ssh://` protocol. 
+Git repos that allow anonymous pulls do not require any additional configuration for authentication.  CommandBox's Git endpoint supports SSH authentication via public/private keys by using the `git+ssh://` protocol.
 
 ```bash
 install git+ssh://site.com:user/repo.git#v1.2.3
 ```
 
+Some Git endpoints (like private Github repos) need a user before the site name in the url string like below:
+
+```bash
+install git+ssh://git@github.com:user/repo.git
+```
+
 > **Info** Note the git+ssh URL is a little different than a HTTP(S) URL. There is a colon (`:`) after the host instead of a forward slash (`/`).
 
-The `git+ssh` endpoint will look for a private SSH key in your `~/.ssh` directory named `id_rsa`, `id_dsa`, or `identity`.  If you are using a multi-key setup with a `~/ssh/config` file, it will be read, and the appropriate key will be used for the host.  The matching public key needs to be registered in the Git server. 
+The `git+ssh` endpoint will look for a private SSH key in your `~/.ssh` directory named `id_rsa`, `id_dsa`, or `identity`.  If you are using a multi-key setup with a `~/ssh/config` file, it will be read, and the appropriate key will be used for the host.  The matching public key needs to be registered in the Git server.
 
 Password authentication is not supported yet for HTTP, HTTPS, or SSH Git protocols.  


### PR DESCRIPTION
Clarify that private github repos need the username of `git@` before the site name (`github.com`). Specified this case in the docs.