### PR TITLE
Change tap location in install docs

### DIFF
--- a/setup/installation.md
+++ b/setup/installation.md
@@ -41,8 +41,8 @@ brew install commandbox
 To stay with current bleeding edge releases use the following:
 
 ```bash
-brew tap Ortus-Solutions/commandbox
-brew install --devel Ortus-Solutions/commandbox/commandbox
+brew tap Ortus-Solutions/boxtap
+brew install --devel Ortus-Solutions/boxtap/commandbox
 ```
 
 Then run the `box` binary to begin the one-time unpacking process.

--- a/setup/installation.md
+++ b/setup/installation.md
@@ -50,6 +50,7 @@ Then run the `box` binary to begin the one-time unpacking process.
 
 Versions will be installed in `/usr/local/Cellar/commandbox`.  To switch between versions, simply use `brew switch commandbox [version number]`
 
+
 ### Manual Installation
 
 Unzip the binary **box** and just double click on it to open the shell terminal.

--- a/setup/installation.md
+++ b/setup/installation.md
@@ -41,8 +41,9 @@ brew install commandbox
 To stay with current bleeding edge releases use the following:
 
 ```bash
-brew tap Ortus-Solutions/boxtap
-brew install --devel Ortus-Solutions/boxtap/commandbox
+brew tap ortus-solutions/boxtap
+brew tap-pin ortus-solutions/boxtap
+brew install --devel commandbox
 ```
 
 Then run the `box` binary to begin the one-time unpacking process.


### PR DESCRIPTION
Because of the way homebrew handles tapped repos, using the Ortus hombrew fork was causing tap installation errors.  This change uses the tap-repo to prevent errors and allows pinning of the repo (which will permanently prefer the Ortus version over the Homebrew master version)