### PR TITLE
Update upgrading.md

### DIFF
--- a/setup/upgrading.md
+++ b/setup/upgrading.md
@@ -46,7 +46,6 @@ Note, if you delete your `{user}/.CommandBox` folder and re-run the executable, 
 If you have used Hombrew to install CommandBox you must use Homebrew for any upgrade, minor or major. To upgrade CommandBox with Homebrew:
 
 ```bash
-brew uninstall commandbox
-brew install commandbox
+brew upgrade commandbox
 ```
 


### PR DESCRIPTION
Upgrading CommandBox on a Mac using the, simpler, inbuilt Homebrew upgrade option now seems stable where as it wasn't originally. I've now used this advice to upgrade to 4.5 and 4.6 successfully.