### PR TITLE
Add note that datasource structs are fixed in Lucee 5.3.1

### DIFF
--- a/task-runners/hitting-your-database.md
+++ b/task-runners/hitting-your-database.md
@@ -27,7 +27,7 @@ So, the first block simply declares a struct that represents a datasource connec
 
 ## Another method
 
-There are a couple tags inside Lucee that don't support this just yet. `<CFDBInfo>` is one of them. [Ticket Here](https://luceeserver.atlassian.net/browse/LDEV-1026) In this case, you need a "proper" datasource defined that you can reference by name. Lucee has some more tricks up its sleeve for this. You can simulate the same thing that happens when you add a datasource to your `Application.cfc` with the following code. This will define a datasource for the duration of the time the CLI is running in memory, but it will be gone the next time you start the CLI.
+There are a couple tags inside Lucee that don't support datasource structs prior to Lucee 5.3.1. `<CFDBInfo>` is one of them. [Ticket Here](https://luceeserver.atlassian.net/browse/LDEV-1026) In this case, you need a "proper" datasource defined that you can reference by name. Lucee has some more tricks up its sleeve for this. You can simulate the same thing that happens when you add a datasource to your `Application.cfc` with the following code. This will define a datasource for the duration of the time the CLI is running in memory, but it will be gone the next time you start the CLI.
 
 ```javascript
 appSettings = getApplicationSettings();


### PR DESCRIPTION
Datasource structs now work with `<cfdbinfo>` and others since Lucee 5.3.1. I thought this made sense to note here, although I guess CommandBox is still based on Lucee 5.2, so maybe that hasn't landed yet in CommandBox?