### PR TITLE
Add missing dot for path

### DIFF
--- a/package-management/code-endpoints/git.md
+++ b/package-management/code-endpoints/git.md
@@ -58,7 +58,7 @@ install git+ssh://git@github.com:user/repo.git
 
 > **Info** Note the git+ssh URL is a little different than a HTTP\(S\) URL. There is a colon \(`:`\) after the host instead of a forward slash \(`/`\).
 
-The `git+ssh` endpoint will look for a private SSH key in your `~/.ssh` directory named `id_rsa`, `id_dsa`, or `identity`. If you are using a multi-key setup with a `~/ssh/config` file, it will be read, and the appropriate key will be used for the host. The matching public key needs to be registered in the Git server.
+The `git+ssh` endpoint will look for a private SSH key in your `~/.ssh` directory named `id_rsa`, `id_dsa`, or `identity`. If you are using a multi-key setup with a `~/.ssh/config` file, it will be read, and the appropriate key will be used for the host. The matching public key needs to be registered in the Git server.
 
 > **Info** If you are deploying to a server and you have not previously logged into the Git server from the new machine you will need to make sure the Git server is added to your `known_hosts` file. The quickest way to do this is to use `git clone git@github.com/user/repo.git` from the terminal OR add the line from your local machine to the server.
 


### PR DESCRIPTION
The .ssh folder inside the user's home directory is incorrectly referenced in the documentation.