### PR TITLE
Typo fix - `testsbox run` to `testbox run`

### DIFF
--- a/package-management/package-scripts.md
+++ b/package-management/package-scripts.md
@@ -26,7 +26,7 @@ You can also create ad-hoc scripts with arbitrary names that contain a collectio
   "slug" : "my-package",
   "version" : "1.0.0",
   "scripts" : {
-   "build" : "!grunt build && testsbox run && run-script generateAPIDocs && bump --patch && publish",
+   "build" : "!grunt build && testbox run && run-script generateAPIDocs && bump --patch && publish",
    "generateAPIDocs" : "docbox generate"
   }
 }


### PR DESCRIPTION
Hope these typo fixes aren't annoying! Just thought I'd clean it up a tad.