### PR TITLE
Adding apt-transport-https to debian instructions

### DIFF
--- a/setup/installation.md
+++ b/setup/installation.md
@@ -58,8 +58,8 @@ Run the following series of commands to add the Ortus signing key, register our 
 
 ```bash
 curl -fsSl https://downloads.ortussolutions.com/debs/gpg | sudo apt-key add -
-echo "deb http://downloads.ortussolutions.com/debs/noarch /" | sudo tee -a /etc/apt/sources.list.d/commandbox.list
-sudo apt-get update && sudo apt-get install commandbox
+echo "deb https://downloads.ortussolutions.com/debs/noarch /" | sudo tee -a /etc/apt/sources.list.d/commandbox.list
+sudo apt-get update && sudo apt-get install apt-transport-https commandbox
 ```
 
 Then run the `box` binary to begin the one-time unpacking process.


### PR DESCRIPTION
Even though you are specifying `downloads.ortussolutions.com` using `http` in the `deb` command, it gets redirected to HTTPS now so apt requires the package `apt-transport-https` in order to install stuff over https.

I've also switched the deb url to `https` to eliminate the unnecessary redirect to https.