### PR TITLE
Added how to hide the FR license key.

### DIFF
--- a/embedded-server/fusionreactor.md
+++ b/embedded-server/fusionreactor.md
@@ -44,6 +44,17 @@ fr register "myLicenseKey"
 
 If you don't have a license, you can sign up for a trial and purchase a license from the [http://www.fusion-reactor.com/](http://www.fusion-reactor.com/?affiliate=ortussolutions) website.
 
+### Hide License Key
+
+By default, the license key will always be displayed on the home page after login. You can turn off the display of the key on a per-server basis or at a global level for all servers.
+
+```text
+// Server specific
+server set fusionreactor.hideLicenseKey=true
+// global default
+config set server.defaults.fusionreactor.hideLicenseKey=true
+```
+
 ## Custom Port
 
 By default, the module always picks a random port to start FusionReactor on. You can also set your FusionReactor port on a per-server basis, or at a global level for all servers \(if using the fancy [host updater module](https://www.forgebox.io//view/commandbox-hostupdater) which prevents port conflicts by binding each site to its own IP\). The default behavior will still be to pick a random port if you don't specify one.


### PR DESCRIPTION
Related to a PR for `commandbox-fusionreactor`. 

https://github.com/bdw429s/commandbox-fusionreactor/pull/15