### PR TITLE
Add gzipEnable as an option to the server.json example

### DIFF
--- a/embedded-server/server.json/README.md
+++ b/embedded-server/server.json/README.md
@@ -37,6 +37,7 @@ Every time you start a server, the settings used to start it are saved in a `ser
         "directoryBrowsing": true,
         "accessLogEnable": true,
         "maxRequests":30,
+        "gzipEnable": true,
         "aliases": {
             "/foo": "../bar",
             "/js": "C:/static/shared/javascript"


### PR DESCRIPTION
this adds gzipEnable as an option to the web object of the server.json file example located here:
https://commandbox.ortusbooks.com/embedded-server/server.json

It was missing before although documented on a different page.