### PR TITLE
Elaborate on how path arguments to watch work

### DIFF
--- a/developing-for-commandbox/commands/watchers-1.md
+++ b/developing-for-commandbox/commands/watchers-1.md
@@ -20,6 +20,11 @@ watch()
 Here's a rundown of the methods used above in the DSL.
 
 * **paths\( ... \)** - Receives a comma-delimtied list of globbing patterns to watch for changes. \(defaults to `**`\)
+    Note that the "paths" here work more like `.gitignore` entries and less like bash paths. Specifically:
+    - A path with a leading slash (or backslash), will be evaluated relative to the current working directory. E.g. `watch /foo` will only watch files in the directory at `./foo`, but not in directories like `./bar/foo`.
+    - A path without a leading slash (or backslash) will be applied as a glob filter to *all files* within the current working directory. E.g. `watch foo` will result in the entire working directory being watched, but only files matching the glob `**foo` will be processed.
+
+    If your watcher seems slow, unresponsive, or is failing to notice some file change events, it is likely that you have it watching too many files. Try specifying more specific paths to the files you want to process, and use leading slashes in your arguments to avoid watching all files in the current working directory.
 * **inDirectory\( ... \)** - Set the base directory that the file globs are relative to. \(defaults to current working directory\)
 * **withDelay\( ... \)** - Set the number of milliseconds between polling the file system. \(defaults to 500 ms\)
 * **onChange\( ... \)** - Pass a closure to be executed when a change has occurred.


### PR DESCRIPTION
Per long CFML Slack discussion in #box-products with @jcberquist and @bdw429s yesterday.

I spent many hours yesterday troubleshooting slow performance in the watcher because I didn't understand how the watch paths worked. I'm hoping to save the next person that trouble.