### PR TITLE
[Running other commands] the command param called name has been renam…

### DIFF
--- a/developing-for-commandbox/commands/running-other-commands.md
+++ b/developing-for-commandbox/commands/running-other-commands.md
@@ -24,9 +24,15 @@ command( ... )
     .run( ... );
 ```
 
+The chained methods make declarative or functional programming possible. However, the command() method will also accept a full command string:
+
+```javascript
+command( 'rm --recurse --force' ).run();
+```
+
 ## command\(\)
 
-This is required to be the first method you call. It creates an instance of the `CommandDSL` class and returns it. It accepts a single parameter called `name` which is the name of the command you wish to run. Type the name exactly as you would in the shell including the namespace, if applicable.
+This is required to be the first method you call. It creates an instance of the `CommandDSL` class and returns it. It accepts a single parameter called `command` which is the name of the command you wish to run. Type the name exactly as you would in the shell including the namespace, if applicable.
 
 ```javascript
 command( 'info' )
@@ -34,6 +40,12 @@ command( 'info' )
 
 command( 'server start' )
     .run();
+```
+
+The `command` param could also accept a full command string, for solutions that do not require a functional appproach.
+
+```javascript
+command( 'rm --recurse --force' ).run();
 ```
 
 ## params\(\)


### PR DESCRIPTION
the command param called name has been renamed to 'command' to indicate that the DSL can be used for functional programming or one can simply pass a full command string. I submitted a PR to commandbox that goes with this PR - in that PR I actually changed the param name to command in util/CommandDSL.cfc