### PR TITLE
Added server rules intro and link to URL Rewrites section

### DIFF
--- a/embedded-server/configuring-your-server/server-rules/README.md
+++ b/embedded-server/configuring-your-server/server-rules/README.md
@@ -1,4 +1,4 @@
-# Server Rules
+# Server Rules with Undertow
 
 CommandBox servers have a method of locking down secure URLs and or implementing any of the Undertow predicate and handlers via a nice text based language. Undertow supports a “predicate language” that allows a string to be parsed into a graph of predicates \(conditions\) and handlers \(actions to take\). Ex:
 
@@ -20,7 +20,7 @@ If you have Tuckey rewrites enabled AND use the Undertow predicate-based server 
 
 ## Create your Rules
 
-Unlike custom Tuckey-based rewrites that must be placed in a single XML file, sever rule can be provided ad-hoc in a variety of locations. They are combined and passed to the server in the order defined. This allows you to easily "layer" custom rules along with out-of-the-box lockdown profiles.
+Unlike custom Tuckey-based rewrites that must be placed in a single XML file, server rules can be provided ad-hoc in a variety of locations. They are combined and passed to the server in the order defined. This allows you to easily "layer" custom rules along with out-of-the-box lockdown profiles.
 
 For maximum configuration options, the following mechanisms are supported for specifying the rules for a given server. Rules are processed in the order listed. i.e., a rule defined in your `server.json` is processed prior to a rule in your `server.default` config setting.
 

--- a/embedded-server/configuring-your-server/url-rewrites.md
+++ b/embedded-server/configuring-your-server/url-rewrites.md
@@ -1,10 +1,10 @@
-# URL Rewrites
+# URL Rewrites with Tuckey
 
 Once you start using the embedded server for your development projects, you may wish to enable URL rewriting. Rewrites are used by most popular frameworks to do things like add the `index.cfm` back into SES URLs.
 
-You may be used to configuring URL rewrites in Apache or IIS, but rewrites are also possible in CommandBox's embedded server via a [Tuckey servlet filter](http://tuckey.org/urlrewrite/).
+You may be used to configuring URL rewrites in Apache or IIS, but rewrites are also possible in CommandBox's embedded server via a [Tuckey servlet filter](http://tuckey.org/urlrewrite/) which uses an xml configuration.
 
-[http://tuckey.org/urlrewrite/](http://tuckey.org/urlrewrite/)
+Commandbox also exposes a way to do url rewrites with the Undertow predicate language. If you missed the (Server Rules)[/embedded-server/configuring-your-server/server-rules] section, go there to learn how to do url rewrites, security, and http header modification in a nice text based language (non-xml). 
 
 ## Default Rules
 


### PR DESCRIPTION
I think is important since 'url rewrite' is a more command search query - so server rules has to get a mention there. Atleast for me I did not know about undertow server rules until Brad mentioned it to me.  if folks take the same path to look up url rewrites then maybe this mention in there will help them learn about the alternative to xml config. 