### PR TITLE
Removing failovermethod property

### DIFF
--- a/setup/installation.md
+++ b/setup/installation.md
@@ -96,7 +96,6 @@ Add the following to: `/etc/yum.repos.d/commandbox.repo`
 ```text
 [CommandBox]
 name=CommandBox $releasever - $basearch
-failovermethod=priority
 baseurl=http://downloads.ortussolutions.com/RPMS/noarch
 enabled=1
 metadata_expire=7d


### PR DESCRIPTION
On rpm/yum/dnf-based distributions like RHEL, RL, Centos etc the `failovermethod` property is deprecated. `dnf` already actively doesn't support it anymore and throws a warning. Given that `yum` is on the way out as tooling and usage of `dnf` is recommended now, we might want to move to providing `dnf` instructions anyway.