### PR TITLE
Revise wording for Windows installation

### DIFF
--- a/setup/installation.md
+++ b/setup/installation.md
@@ -18,9 +18,13 @@ commandbox_home=../boxHome
 
 ## Windows
 
-Unzip the executable **box.exe** and just double click on it to open the shell. When you are finished running commands, you can just close the window, or type `exit`.
+Extract the executable **box.exe** from the downloaded zip file, placing it anywhere you prefer where you can then execute it when needed, such as from the Windows command line/terminal. You can also run it directly Windows File Explorer, where you would just double click on the exe,which will open the CommandBox shell in a new terminal window.
 
-> **Hint** You can make the `box.exe` available in any Windows terminal by adding its location to the `PATH` system environment variable. See [http://www.computerhope.com/issues/ch000549.htm](http://www.computerhope.com/issues/ch000549.htm)
+> **Warning** On Windows 10 and above, the first time you try to run via Windows File Explorer an exe that you've downloaded, Windows Defender Smartscreen will popup with a warning that "Windows protected your PC". You will need to choose the offered "More info" link and then the offered "Run anway" button, to proceed.
+
+> **Hint** When running from the Windows command line/terminal, you can make it so that you can run `box.exe` while you are in any folder (not just the one where you placed it), by simply adding the exe's location to the Windows `PATH` system environment variable. See [http://www.computerhope.com/issues/ch000549.htm](http://www.computerhope.com/issues/ch000549.htm)
+
+When you are finished running commands in the CommandBox shell, type `exit`. Or if you ran the box.exe from within Windows File Explorer, you can just close the terminal window which that opened.
 
 ## Mac/  \*Unix
 


### PR DESCRIPTION
The most important change is in the first sentence discussing Windows: the previous wording said to "Unzip the executable box.exe"...which could be misread, with someone thinking they need to unzip the exe itself (into its underlying files, which is possible), but that's not what's intended here at all.  

Then while I was here, I went ahead and tweaked the next couple of sentences to refine/clarify the points further, especially adding the SmartScreen prompt, since the current docs did propose how folks could run the exe by "double-clicking" on it, which is when Smartscreen kicks in (to be clear, it does NOT apply when instead running the exe from the command line, even for the first time after downloading it. That surprises me, too. I decided to clarify that here rather than in the text, in case anyone may feel the need to confirm that for themselves before accepting that part of this PR.)