### PR TITLE
In system settings, avoid using inner single quotes in expansions

### DIFF
--- a/usage/system-settings.md
+++ b/usage/system-settings.md
@@ -18,7 +18,11 @@ If a system setting can't be found in a Java property or an environment variable
 server start port=${SERVER_PORT:8080}
 ```
 
-This does assume that your default value will never contain a colon!
+```text
+server set web.host=${SERVER_HOST:localsite.dev}
+```
+
+This does assume that your default value will never contain a colon! Also do not use inner single quotes for environment variable name nor the default value.
 
 ## Lookup Order
 

--- a/usage/system-settings.md
+++ b/usage/system-settings.md
@@ -22,7 +22,7 @@ server start port=${SERVER_PORT:8080}
 server set web.host=${SERVER_HOST:localsite.dev}
 ```
 
-This does assume that your default value will never contain a colon! Also do not use inner single quotes for environment variable name nor the default value.
+This does assume that your system setting name will never contain a colon! Also do not use inner single quotes for system setting name nor the default value.
 
 ## Lookup Order
 


### PR DESCRIPTION
In system settings, when using the expansion syntax do not use inner single quotes for the environment variable names nor the default values.