### PR TITLE
Update running-other-commands.md

### DIFF
--- a/task-runners/running-other-commands.md
+++ b/task-runners/running-other-commands.md
@@ -13,6 +13,15 @@ command( 'version' )
 
 This runs the `version` command and the output will be flushed to the console.
 
+We can also run commands that exist outside of Commandbox. This will run 'git --version':
+
+```javascript
+command('run')
+	.params('git')
+	.flags( 'version' )
+	.run();
+```
+
 Here are all the possible DSL methods that we'll unpack below:
 
 ```javascript


### PR DESCRIPTION
Adding an example using command(run) to demonstrate how to run commands outside of Commandbox.