### PR TITLE
Update installation.md

### DIFF
--- a/setup/installation.md
+++ b/setup/installation.md
@@ -45,7 +45,7 @@ brew install --head ortus-solutions/homebrew-boxtap/commandbox
 
 Then run the `box` binary to begin the one-time unpacking process.
 
-Versions will be installed in `/usr/local/Cellar/commandbox`. To switch between versions, you will need to install the new version - either using the bleeding edge tap or the main repo. For example to switch to a (very) old version:
+Versions will be installed in `/opt/homebrew/Cellar/commandbox`. To switch between versions, you will need to install the new version - either using the bleeding edge tap or the main repo. For example to switch to a (very) old version:
 
 ```
 brew install commandbox@5.1.1
@@ -60,7 +60,7 @@ brew uninstall ortus-solutions/homebrew-boxtap/commandbox
 brew install commandbox
 ```
 
-If you want to use a `commandbox.properties` file as mentioned above, even though the symlink is added in `/usr/local/bin`, your `box` _binary_ file will be in the `/usr/local/Cellar/commandbox/<version>/libexec/bin/` directory where you should place your `commandbox.properties` file. There will also be a `box` _binary_ in the `/usr/local/Cellar/commandbox/<version>/bin/` directory where you should place the `jre` if you want CommandBox to use a version of Java that is different from your default version reported by `java -version`.
+If you want to use a `commandbox.properties` file as mentioned above, even though the symlink is added in `/usr/local/bin`, your `box` _binary_ file will be in the `/opt/homebrew/Cellar/commandbox/<version>/libexec/bin/` directory where you should place your `commandbox.properties` file. There will also be a `box` _binary_ in the `/opt/homebrew/Cellar/commandbox/<version>/bin/` directory where you should place the `jre` if you want CommandBox to use a version of Java that is different from your default version reported by `java -version`.
 
 When using Homebrew to install CommandBox you must use Homebrew for any upgrade, minor or major. To upgrade CommandBox with Homebrew:
 
@@ -68,7 +68,7 @@ When using Homebrew to install CommandBox you must use Homebrew for any upgrade,
 brew upgrade commandbox
 ```
 
-NOTE: If you use Homebrew to upgrade your version of CommandBox it will erase your `/usr/local/Cellar/commandbox/<current_version>/` folder. So before upgrading, take a copy of your `/usr/local/Cellar/commandbox/<current_version>/libexec/bin/commandbox.properties` file to drop back into `/usr/local/Cellar/commandbox/<new_version>/libexec/bin/` before running `box` for the first time after upgrading.
+NOTE: If you use Homebrew to upgrade your version of CommandBox it will erase your `/opt/homebrew/Cellar/commandbox/<current_version>/` folder. So before upgrading, take a copy of your `/opt/homebrew/Cellar/commandbox/<current_version>/libexec/bin/commandbox.properties` file to drop back into `/opt/homebrew/Cellar/commandbox/<new_version>/libexec/bin/` before running `box` for the first time after upgrading.
 
 ### Manual Installation
 


### PR DESCRIPTION
Based on output from the -clidebug I found that the path to where Homebrew installed commandbox differs from what was described here. This update changes the path to the commandbox binaries, now found in /opt/homebrew/Cellar/commandbox.