### PR TITLE
Change the designator for stable install

### DIFF
--- a/package-management/box.json/dependencies.md
+++ b/package-management/box.json/dependencies.md
@@ -10,7 +10,7 @@ The key is the unique slug of the package and the value is the a semvar range, l
 
 ```javascript
 "dependencies" : {
-    "coldbox" : "x" // latest version from ForgeBox
+    "coldbox" : "stable" // latest version from ForgeBox
     "cborm" : "1.0.1", // a specific version from ForgeBox
     "private-package" : "C:\\libs\\foo", // local folder
     "private-package2" : "C:\\libs\\foo.zip", // local file


### PR DESCRIPTION
The placeholder "x" didn't install the stable version for me. I had to change that to "stable" to get the stable release of the module to install.