### PR TITLE
Update apt-based GPG key process

### DIFF
--- a/setup/installation.md
+++ b/setup/installation.md
@@ -91,12 +91,9 @@ Run the following series of commands to add the Ortus signing key, register our 
 ( This first install routine also works for the Raspberry Pi. )
 
 ```bash
-wget -O- https://downloads.ortussolutions.com/debs/gpg |\
-    gpg --dearmor |\
-    sudo tee /usr/share/keyrings/ortussolutions.gpg > /dev/null
+curl -fsSl https://downloads.ortussolutions.com/debs/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/ortussolutions.gpg > /dev/null
 
-echo "deb [signed-by=/usr/share/keyrings/ortussolutions.gpg] https://downloads.ortussolutions.com/debs/noarch /" |\
-    sudo tee /etc/apt/sources.list.d/commandbox.list
+echo "deb [signed-by=/usr/share/keyrings/ortussolutions.gpg] https://downloads.ortussolutions.com/debs/noarch /" | sudo tee /etc/apt/sources.list.d/commandbox.list
 
 sudo apt-get update && sudo apt-get install apt-transport-https commandbox
 ```

--- a/setup/installation.md
+++ b/setup/installation.md
@@ -91,8 +91,13 @@ Run the following series of commands to add the Ortus signing key, register our 
 ( This first install routine also works for the Raspberry Pi. )
 
 ```bash
-curl -fsSl https://downloads.ortussolutions.com/debs/gpg | sudo apt-key add -
-echo "deb https://downloads.ortussolutions.com/debs/noarch /" | sudo tee -a /etc/apt/sources.list.d/commandbox.list
+wget -O- https://downloads.ortussolutions.com/debs/gpg |\
+    gpg --dearmor |\
+    sudo tee /usr/share/keyrings/ortussolutions.gpg > /dev/null
+
+echo "deb [signed-by=/usr/share/keyrings/ortussolutions.gpg] https://downloads.ortussolutions.com/debs/noarch /" |\
+    sudo tee /etc/apt/sources.list.d/commandbox.list
+
 sudo apt-get update && sudo apt-get install apt-transport-https commandbox
 ```
 


### PR DESCRIPTION
A lot of `apt-key`'s functionality has been deprecated and it's considered bad practice to write into `trusted.gpg` or `trusted.gpg.d` as they key then essentially get added to every repository.

The above change ties the GPG key to the commandbox repo only.

It seems though that there's not a 100% established process of where to download and store the key at. People seem to be divided between `/usr/share/keyrings` and `/etc/apt/keyrings` . I went with the previous for all my setup.