### PR TITLE
fix: typo in the explanation paragraph (asyc -> async)

### DIFF
--- a/task-runners/sending-e-mail.md
+++ b/task-runners/sending-e-mail.md
@@ -1,6 +1,6 @@
 # Sending E-mail
 
-To send email, use `cfmail` tag making sure you set `asyc=false` (see below). Not setting this flag to `false` may result in undelivered email because mail may still exist in Lucee spooler (Lucee tasks) when your task runner exits.
+To send email, use `cfmail` tag making sure you set `async=false` (see below). Not setting this flag to `false` may result in undelivered email because mail may still exist in Lucee spooler (Lucee tasks) when your task runner exits.
 
 ```javascript
 mail 


### PR DESCRIPTION
This fixes a small typo in the paragraph above the code documentation