### PR TITLE
docs: fix typo in bindings readme file

### DIFF
--- a/embedded-server/configuring-your-server/bindings/README.md
+++ b/embedded-server/configuring-your-server/bindings/README.md
@@ -226,7 +226,7 @@ HTTP/2 is enabled by default. The legacy `web.http2enable` flag is still obeyed 
 To configure a single SSL Server cert, you can specify the following keys inside the binding:
 
 * `certFile` - A PEM-encoded DER cert or a PFX file
-* `keyFile` - THe Private key (not used for PFX)
+* `keyFile` - The Private key (not used for PFX)
 * `keyPass` - The key pass or PFX pass. Blank if not used
 
 {% code title="server.json" %}


### PR DESCRIPTION
This PR fixes the small typo in binding readme file.

-> T**H**E -> T**h**e